### PR TITLE
Add tests for statevector_gpu

### DIFF
--- a/test/terra/backends/qasm_simulator/qasm_snapshot.py
+++ b/test/terra/backends/qasm_simulator/qasm_snapshot.py
@@ -48,7 +48,8 @@ class QasmSnapshotStatevectorTests:
 
     SIMULATOR = QasmSimulator()
     SUPPORTED_QASM_METHODS = [
-        'automatic', 'statevector', 'matrix_product_state'
+        'automatic', 'statevector', 'statevector_gpu',
+        'statevector_fake_gpu', 'matrix_product_state'
     ]
     BACKEND_OPTS = {}
 
@@ -510,7 +511,8 @@ class QasmSnapshotProbabilitiesTests:
 
     SIMULATOR = QasmSimulator()
     SUPPORTED_QASM_METHODS = [
-        'automatic', 'statevector', 'density_matrix', 'matrix_product_state'
+        'automatic', 'statevector', 'statevector_gpu', 'statevector_fake_gpu',
+        'density_matrix', 'matrix_product_state'
     ]
     BACKEND_OPTS = {}
 
@@ -590,7 +592,8 @@ class QasmSnapshotExpValPauliTests:
 
     SIMULATOR = QasmSimulator()
     SUPPORTED_QASM_METHODS = [
-        'automatic', 'statevector', 'matrix_product_state'
+        'automatic', 'statevector', 'statevector_gpu', 'statevector_fake_gpu',
+        'matrix_product_state'
     ]
     BACKEND_OPTS = {}
 
@@ -674,7 +677,8 @@ class QasmSnapshotExpValMatrixTests:
 
     SIMULATOR = QasmSimulator()
     SUPPORTED_QASM_METHODS = [
-        'automatic', 'statevector', 'matrix_product_state'
+        'automatic', 'statevector', 'statevector_gpu', 'statevector_fake_gpu',
+        'matrix_product_state'
     ]
     BACKEND_OPTS = {}
 

--- a/test/terra/backends/test_qasm_statevector_gpu_simulator.py
+++ b/test/terra/backends/test_qasm_statevector_gpu_simulator.py
@@ -1,0 +1,96 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018, 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+QasmSimulator Statevector GPU method integration tests
+"""
+
+import unittest
+from test.terra import common
+from test.terra.decorators import requires_gpu
+
+# Basic circuit instruction tests
+from test.terra.backends.qasm_simulator.qasm_reset import QasmResetTests
+from test.terra.backends.qasm_simulator.qasm_measure import QasmMeasureTests
+from test.terra.backends.qasm_simulator.qasm_measure import QasmMultiQubitMeasureTests
+from test.terra.backends.qasm_simulator.qasm_cliffords import QasmCliffordTests
+from test.terra.backends.qasm_simulator.qasm_cliffords import QasmCliffordTestsWaltzBasis
+from test.terra.backends.qasm_simulator.qasm_cliffords import QasmCliffordTestsMinimalBasis
+from test.terra.backends.qasm_simulator.qasm_noncliffords import QasmNonCliffordTests
+from test.terra.backends.qasm_simulator.qasm_noncliffords import QasmNonCliffordTestsWaltzBasis
+from test.terra.backends.qasm_simulator.qasm_noncliffords import QasmNonCliffordTestsMinimalBasis
+from test.terra.backends.qasm_simulator.qasm_unitary_gate import QasmUnitaryGateTests
+from test.terra.backends.qasm_simulator.qasm_initialize import QasmInitializeTests
+# Conditional instruction tests
+from test.terra.backends.qasm_simulator.qasm_conditional import QasmConditionalGateTests
+from test.terra.backends.qasm_simulator.qasm_conditional import QasmConditionalUnitaryTests
+from test.terra.backends.qasm_simulator.qasm_conditional import QasmConditionalKrausTests
+# Algorithm circuit tests
+from test.terra.backends.qasm_simulator.qasm_algorithms import QasmAlgorithmTests
+from test.terra.backends.qasm_simulator.qasm_algorithms import QasmAlgorithmTestsWaltzBasis
+from test.terra.backends.qasm_simulator.qasm_algorithms import QasmAlgorithmTestsMinimalBasis
+# Noise model simulation tests
+from test.terra.backends.qasm_simulator.qasm_noise import QasmReadoutNoiseTests
+from test.terra.backends.qasm_simulator.qasm_noise import QasmPauliNoiseTests
+from test.terra.backends.qasm_simulator.qasm_noise import QasmResetNoiseTests
+from test.terra.backends.qasm_simulator.qasm_noise import QasmKrausNoiseTests
+# Snapshot tests
+from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotStatevectorTests
+from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotDensityMatrixTests
+from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotStabilizerTests
+from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotProbabilitiesTests
+from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotExpValPauliTests
+from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotExpValMatrixTests
+# Other tests
+from test.terra.backends.qasm_simulator.qasm_method import QasmMethodTests
+
+
+@requires_gpu
+class TestQasmStatevectorSimulator(common.QiskitAerTestCase,
+                                   QasmMethodTests,
+                                   QasmMeasureTests,
+                                   QasmMultiQubitMeasureTests,
+                                   QasmResetTests,
+                                   QasmConditionalGateTests,
+                                   QasmConditionalUnitaryTests,
+                                   QasmConditionalKrausTests,
+                                   QasmCliffordTests,
+                                   QasmCliffordTestsWaltzBasis,
+                                   QasmCliffordTestsMinimalBasis,
+                                   QasmNonCliffordTests,
+                                   QasmNonCliffordTestsWaltzBasis,
+                                   QasmNonCliffordTestsMinimalBasis,
+                                   QasmAlgorithmTests,
+                                   QasmAlgorithmTestsWaltzBasis,
+                                   QasmAlgorithmTestsMinimalBasis,
+                                   QasmUnitaryGateTests,
+                                   QasmInitializeTests,
+                                   QasmReadoutNoiseTests,
+                                   QasmPauliNoiseTests,
+                                   QasmResetNoiseTests,
+                                   QasmKrausNoiseTests,
+                                   QasmSnapshotStatevectorTests,
+                                   QasmSnapshotDensityMatrixTests,
+                                   QasmSnapshotProbabilitiesTests,
+                                   QasmSnapshotExpValPauliTests,
+                                   QasmSnapshotExpValMatrixTests,
+                                   QasmSnapshotStabilizerTests):
+    """QasmSimulator statevector_gpu method tests."""
+
+    BACKEND_OPTS = {
+        "seed_simulator": 54321,
+        "method": "statevector_gpu"
+    }
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/terra/backends/test_qasm_statevector_gpu_simulator.py
+++ b/test/terra/backends/test_qasm_statevector_gpu_simulator.py
@@ -50,13 +50,10 @@ from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotStabili
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotProbabilitiesTests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotExpValPauliTests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotExpValMatrixTests
-# Other tests
-from test.terra.backends.qasm_simulator.qasm_method import QasmMethodTests
 
 
 @requires_gpu
 class TestQasmStatevectorSimulator(common.QiskitAerTestCase,
-                                   QasmMethodTests,
                                    QasmMeasureTests,
                                    QasmMultiQubitMeasureTests,
                                    QasmResetTests,

--- a/test/terra/decorators.py
+++ b/test/terra/decorators.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2018.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Decorator for using with Qiskit Aer unit tests."""
+
+import unittest
+
+from qiskit import QuantumCircuit, assemble
+from qiskit.providers.aer import QasmSimulator
+from qiskit.providers.aer import AerError
+
+
+def is_qasm_method_available(method):
+    """Check if input method is available for the qasm simulator."""
+    # Simple test circuit that should work on all simulators.
+    dummy_circ = QuantumCircuit(1)
+    dummy_circ.iden(0)
+    qobj = assemble(dummy_circ, optimization_level=0)
+    backend_options = {"method": method}
+    try:
+        job = QasmSimulator().run(qobj, backend_options=backend_options)
+        result = job.result()
+        return result.success
+    except AerError:
+        return False
+    return True
+
+
+def requires_gpu(test_item):
+    """Decorator that skips test if GPU statevector method is not available.
+
+    Args:
+        test_item (callable): function or class to be decorated.
+
+    Returns:
+        callable: the decorated function.
+    """
+    reason = 'GPU not available, skipping test'
+    skip = not is_qasm_method_available("statevector_gpu") 
+    return unittest.skipIf(skip, reason)(test_item)


### PR DESCRIPTION
Adds decorator to skip tests if statevector_gpu method is not available.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

* Adds statevector unittests for statevector_gpu qasm simulation method
* Adds a `requires_gpu` decorator for tests so they can be skipped if the gpu backend isn't built.

### Details and comments


